### PR TITLE
fix: update profile data

### DIFF
--- a/src/views/Setup/EditProfile.vue
+++ b/src/views/Setup/EditProfile.vue
@@ -169,7 +169,30 @@ export default class EditProfile extends Vue {
 
     async mounted() {
         await utils.tryEnsureOrRedirect(this.$route, this.$router);
+        this.loadUserData();
+    }
 
+    async updated() {
+        const loginUser = RSS3.getLoginUser();
+        const userChanged = this.ethAddress !== loginUser.address;
+        if (userChanged) {
+            this.clearProfileData();
+            this.loadUserData();
+        }
+    }
+
+    clearProfileData() {
+        this.profile = {
+            avatar: config.defaultAvatar,
+            name: '',
+            bio: '',
+            link: '',
+        };
+        this.ethAddress = '';
+        this.accounts = [];
+    }
+
+    async loadUserData() {
         const loginUser = RSS3.getLoginUser();
         await RSS3.setPageOwner(loginUser.address);
         this.ethAddress = loginUser.address;


### PR DESCRIPTION
Bug: if you relogin with a different account and open the profile editor, you'll see the previous account's info.
Fix: check the address every time when the component update then update profile data if the eth address has changed.