### PR TITLE
fix: invalid home item in header menu

### DIFF
--- a/src/components/Common/Header.vue
+++ b/src/components/Common/Header.vue
@@ -118,12 +118,10 @@ export default class Header extends Vue {
     }
 
     toPublicPage() {
-        if (this.rns && this.ethAddress) {
-            if (this.rns && config.subDomain.isSubDomainMode) {
-                window.location.href = `//${this.rns}.${config.subDomain.rootDomain}`;
-            } else {
-                window.location.href = `//${config.subDomain.rootDomain}/${this.ethAddress}`;
-            }
+        if (this.rns) {
+            window.location.href = `//${this.rns}.${config.subDomain.rootDomain}`;
+        } else {
+            window.location.href = `//${config.subDomain.rootDomain}/${this.ethAddress}`;
         }
     }
 


### PR DESCRIPTION
If users are not registered with RNS, they will not be able to use the home button.

https://user-images.githubusercontent.com/36319157/155918118-416bf2c2-a99f-41bd-94e5-45fb916cfdd3.mp4

