### PR TITLE
fix: hybrid switcher component overflow

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -266,29 +266,25 @@
                 <div class="affix-container sticky">
                     <TransBarCard title="Content" :haveDetails="true" :haveContent="false">
                         <template #header>
-                            <div class="flex flex-col gap-y-2" :class="{ 'pointer-events-none': isLoadingContents }">
-                                <div class="flex items-center justify-between gap-2" @click="toggleWeb3Only()">
-                                    <h2
-                                        class="text-black text-opacity-50"
-                                        :class="{ 'translate-x-5 text-opacity-80': isWeb3Only }"
-                                    >
-                                        Web3 Only
-                                    </h2>
+                            <div
+                                class="flex items-center justify-between space-x-2"
+                                :class="[isLoadingContents ? 'pointer-events-none' : 'cursor-pointer']"
+                                @click="toggleWeb3Only()"
+                            >
+                                <h2 class="text-black text-opacity-50" :class="{ 'text-opacity-80': isWeb3Only }">
+                                    Web3 Only
+                                </h2>
+                                <div
+                                    class="flex h-6 w-11 items-center rounded-full bg-gray-500 bg-opacity-10 p-1 duration-200 ease-in-out"
+                                >
                                     <div
-                                        class="flex h-6 w-11 cursor-pointer items-center rounded-full bg-gray-500 bg-opacity-10 p-1 duration-200 ease-in-out"
-                                    >
-                                        <div
-                                            class="h-4 w-4 transform rounded-full bg-black bg-opacity-50 shadow-md duration-200 ease-in-out"
-                                            :class="{ 'translate-x-5 bg-opacity-80': !isWeb3Only }"
-                                        />
-                                    </div>
-                                    <h2
-                                        class="text-black text-opacity-50"
-                                        :class="{ 'translate-x-5 text-opacity-80': !isWeb3Only }"
-                                    >
-                                        Hybrid
-                                    </h2>
+                                        class="h-4 w-4 transform rounded-full bg-black bg-opacity-50 shadow-md duration-200 ease-in-out"
+                                        :class="{ 'translate-x-5 bg-opacity-80': !isWeb3Only }"
+                                    ></div>
                                 </div>
+                                <h2 class="text-black text-opacity-50" :class="{ 'text-opacity-80': !isWeb3Only }">
+                                    Hybrid
+                                </h2>
                             </div>
                         </template>
                         <template #details>


### PR DESCRIPTION
This UI bug can only be reproduced in the `develop` branch.

### Before
<img width="407" alt="image" src="https://user-images.githubusercontent.com/36319157/156127908-dcf03718-0016-4f8f-a432-4f84346b73b9.png">

### Now
<img width="405" alt="image" src="https://user-images.githubusercontent.com/36319157/156127967-055ddd0f-9e10-4ae1-bf58-166de7cc2dc1.png">
